### PR TITLE
Add path fuzzer

### DIFF
--- a/examples/path/fuzz.js
+++ b/examples/path/fuzz.js
@@ -2,28 +2,15 @@ const path = require('path')
 
 async function fuzz (bytes) {
   const string = String.fromCodePoint(...bytes)
-  try {
-    path.basename(string)
-    path.dirname(string)
-    path.extname(string)
-    path.isAbsolute(string)
-    path.join(string)
-    path.normalize(string)
-    path.parse(string)
-    path.resolve(string)
-    path.toNamespacedPath(string)
-  } catch (error) {
-    if (!acceptable(error)) throw error
-  }
+  path.basename(string)
+  path.dirname(string)
+  path.extname(string)
+  path.isAbsolute(string)
+  path.join(string)
+  path.normalize(string)
+  path.parse(string)
+  path.resolve(string)
+  path.toNamespacedPath(string)
 }
-
-function acceptable (error) {
-  return !!expected
-    .find(message => error.message.startsWith(message))
-}
-
-const expected = [
-  
-]
 
 exports.fuzz = fuzz

--- a/examples/path/fuzz.js
+++ b/examples/path/fuzz.js
@@ -1,0 +1,29 @@
+const path = require('path')
+
+async function fuzz (bytes) {
+  const string = String.fromCodePoint(...bytes)
+  try {
+    path.basename(string)
+    path.dirname(string)
+    path.extname(string)
+    path.isAbsolute(string)
+    path.join(string)
+    path.normalize(string)
+    path.parse(string)
+    path.resolve(string)
+    path.toNamespacedPath(string)
+  } catch (error) {
+    if (!acceptable(error)) throw error
+  }
+}
+
+function acceptable (error) {
+  return !!expected
+    .find(message => error.message.startsWith(message))
+}
+
+const expected = [
+  
+]
+
+exports.fuzz = fuzz

--- a/examples/path/package.json
+++ b/examples/path/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "path-fuzz",
+    "version": "1.0.0",
+    "main": "fuzz.js",
+    "license": "ISC"
+}


### PR DESCRIPTION
Adds file path string fuzzer. Targets the [path](https://nodejs.org/dist/latest/docs/api/path.html) module in the Node.js stdlib. Follows the go-fuzz pattern of running all possible path methods on the fuzz.

This one doesn't seem to be hitting any expected errors so I left out the error exclusion logic.

Closes #8.