### PR TITLE
Add url fuzzer

### DIFF
--- a/examples/url/fuzz.js
+++ b/examples/url/fuzz.js
@@ -1,0 +1,44 @@
+const url = require('url')
+
+async function fuzz (bytes) {
+  const string = String.fromCodePoint(...bytes)
+  try {
+    whatwg(string)
+    params(string)
+    legacy(string)
+  } catch (error) {
+    if (!acceptable(error)) throw error
+  }
+}
+
+function whatwg (string) {
+  const parsed = new url.URL(string)
+  parsed.toString()
+  parsed.toJSON()
+}
+
+function params (string) {
+  const parsed = new url.URLSearchParams(string)
+  parsed.toString()
+}
+
+function legacy (string) {
+  /* eslint-disable-next-line node/no-deprecated-api */
+  const parsed = url.parse(string)
+  url.format(parsed)
+}
+
+function acceptable (error) {
+  return (
+    error instanceof URIError ||
+    expected.code.includes(error.code)
+  )
+}
+
+const expected = {
+  code: [
+    'ERR_INVALID_URL'
+  ]
+}
+
+exports.fuzz = fuzz

--- a/examples/url/package.json
+++ b/examples/url/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "url-fuzz",
+    "version": "1.0.0",
+    "main": "fuzz.js",
+    "license": "ISC"
+}


### PR DESCRIPTION
Adds a URL fuzzer to examples. Targets the [url](https://nodejs.org/dist/latest/docs/api/url.html) module in the Node.js standard library. Follows the go-fuzz pattern of doing round trip processing by parsing fuzz then stringifying the result.

Treats as expected errors the JavaScript error type `URIError` and the Node.js error code `ERR_INVALID_URL`.

Closes #9.