### PR TITLE
Add GIF fuzzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,6 @@ any unnecessary work is done.
 * [js-yaml: Crash/TypeError](https://github.com/nodeca/js-yaml/issues/524)
 * [js-yaml: Crash/TypeError](https://github.com/nodeca/js-yaml/issues/525)
 * [asciidoctor: Hang/DoS](https://github.com/asciidoctor/asciidoctor/issues/3472)
+* [deanm/omggif: Crash/TypeError](https://github.com/deanm/omggif/issues/41)
 
 **Feel free to add bugs that you found with jsfuzz to this list via pull-request**

--- a/examples/gif/fuzz.js
+++ b/examples/gif/fuzz.js
@@ -1,0 +1,24 @@
+const omggif = require('omggif')
+
+async function fuzz (bytes) {
+  try {
+    omggif.GifReader(bytes)
+  } catch (error) {
+    if (!acceptable(error)) throw error
+  }
+}
+
+function acceptable (error) {
+  return !!expected
+    .find(message => error.message.startsWith(message))
+}
+
+const expected = [
+  'Invalid GIF 87a/89a header',
+  'Unknown gif block',
+  'Invalid block size',
+  'Invalid graphics extension block',
+  'Unknown graphic control label'
+]
+
+exports.fuzz = fuzz

--- a/examples/gif/package-lock.json
+++ b/examples/gif/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "gif-fuzz",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "omggif": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+            "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
+        }
+    }
+}

--- a/examples/gif/package.json
+++ b/examples/gif/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "gif-fuzz",
+    "version": "1.0.0",
+    "main": "fuzz.js",
+    "license": "ISC",
+    "dependencies": {
+        "omggif": "^1.0.10"
+    }
+}


### PR DESCRIPTION
Adds GIF image format fuzzer. Targets the [omggif](https://www.npmjs.com/package/omggif) module. Tests image decoding from binary data.

Accepts all errors decoding can raise. Full list was found by examining the code.

Closes #7.