### PR TITLE
Add zlib fuzzer

### DIFF
--- a/examples/zlib/fuzz.js
+++ b/examples/zlib/fuzz.js
@@ -1,0 +1,36 @@
+const pako = require('pako')
+
+async function fuzz (bytes) {
+  try {
+    pako.deflate(bytes)
+    pako.inflate(bytes)
+  } catch (error) {
+    if (!acceptable(error)) throw error
+  }
+}
+
+function acceptable (error) {
+  return (
+    typeof error === 'string' &&
+    !!expected.find(message => error.startsWith(message))
+  )
+}
+
+const expected = [
+  'buffer error',
+  'incorrect header check',
+  'unknown compression method',
+  'invalid window size',
+  'invalid distance',
+  'invalid block type',
+  'invalid code lengths',
+  'too many length or distance symbols',
+  'invalid stored block lengths',
+  'need dictionary',
+  'incorrect data check',
+  'invalid literal/length code',
+  'invalid bit length repeat',
+  'invalid code'
+]
+
+exports.fuzz = fuzz

--- a/examples/zlib/package-lock.json
+++ b/examples/zlib/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "zlib-fuzz",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "pako": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+        }
+    }
+}

--- a/examples/zlib/package.json
+++ b/examples/zlib/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "zlib-fuzz",
+    "version": "1.0.0",
+    "main": "fuzz.js",
+    "license": "ISC",
+    "dependencies": {
+        "pako": "^1.0.10"
+    }
+}


### PR DESCRIPTION
Adds zlib compression format fuzzer. Targets the [pako](https://www.npmjs.com/package/pako) module. Follows the go-fuzz pattern of testing inflation and deflation.

Accepts a set of errors thrown by the module on invalid compressed data.

Closes #10.