### PR TITLE
Add support for --only-ascii

### DIFF
--- a/src/corpus.ts
+++ b/src/corpus.ts
@@ -14,9 +14,11 @@ export class Corpus {
     private corpusPath: string | undefined;
     private maxInputSize: number;
     private seedLength: number;
+    private readonly onlyAscii: boolean;
 
-    constructor(dir: string[]) {
+    constructor(dir: string[], onlyAscii: boolean) {
         this.inputs = [];
+        this.onlyAscii = onlyAscii;
         this.maxInputSize = 4096;
         for (let i of dir) {
             if (!fs.existsSync(i)) {
@@ -104,6 +106,16 @@ export class Corpus {
             return this.rand(Math.min(32, n)) + 1
         } else {
             return this.rand(n) + 1;
+        }
+    }
+
+    toAscii(buf: Buffer) {
+        let x;
+        for (let i = 0; i < buf.length; i++) {
+            x = buf[i] & 127;
+            if ((x < 0x20 || x > 0x7E) && x !== 0x09 && (x < 0xA || x > 0xD)) {
+                buf[i] = 0x20;
+            }
         }
     }
 
@@ -342,6 +354,11 @@ export class Corpus {
         if (res.length > this.maxInputSize) {
             res = res.slice(0, this.maxInputSize)
         }
+
+        if (this.onlyAscii) {
+            this.toAscii(res);
+        }
+
         return res;
     }
 }

--- a/src/fuzzer.ts
+++ b/src/fuzzer.ts
@@ -33,6 +33,7 @@ export class Fuzzer {
     private regression: boolean;
     private verse: Verse | null;
     private readonly versifier: boolean;
+    private readonly onlyAscii: boolean;
 
     constructor(target: string,
                 dir: string[],
@@ -40,9 +41,11 @@ export class Fuzzer {
                 rssLimitMb: number,
                 timeout: number,
                 regression: boolean,
+                onlyAscii: boolean,
                 versifier: boolean) {
         this.target = target;
-        this.corpus = new Corpus(dir);
+        this.corpus = new Corpus(dir, onlyAscii);
+        this.onlyAscii = onlyAscii;
         this.versifier = versifier;
         this.verse = null;
         this.total_executions = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ function startFuzzer(argv: any) {
         argv.rssLimitMb,
         argv.timeout,
         argv.regression,
+        argv.onlyAscii,
         argv.versifier);
     fuzzer.start()
 }
@@ -55,6 +56,11 @@ require('yargs')
         type: 'boolean',
         description: 'use versifier algorithm (good for text based protocols)',
         default: true,
+    })
+    .option('only-ascii', {
+        type: 'boolean',
+        description: 'generate only ASCII (isprint+isspace) inputs',
+        default: false,
     })
     .help()
     .argv;


### PR DESCRIPTION
The logic behind this flag is 100% based on libfuzzer's [`MutationDispatcher::MutateImpl`](https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/fuzzer/FuzzerMutate.cpp#L507) and will help dealing with parsers rejecting non-ASCII characters.